### PR TITLE
client/css: fix comment word-break

### DIFF
--- a/client/css/comment-control.styl
+++ b/client/css/comment-control.styl
@@ -129,7 +129,7 @@ $comment-border-color = #DDD
 .comment-content
     p
         word-wrap: normal
-        word-break: break-all
+        word-break: break-word
 
     ul, ol
         list-style-position: inside


### PR DESCRIPTION
`break-all` makes it hard to read actual comments.